### PR TITLE
Fix: news cache duration to one hour

### DIFF
--- a/src/modules/news/news.controller.ts
+++ b/src/modules/news/news.controller.ts
@@ -11,7 +11,7 @@ let newsCache: NewsCache = {
     timestamp: 0,
 };
 
-const CACHE_DURATION = 60// 60// 1000; // 1 hour
+const CACHE_DURATION = 60 * 60 * 1000; // 1 hour
 
 
 


### PR DESCRIPTION
  - Corrects broken CACHE_DURATION expression in news controller
  - Prevents constant re-fetching and restores intended 1-hour cache behavior
  - 