### PR TITLE
fix: remove @tiptap/pm from manualChunks to resolve build error

### DIFF
--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -68,7 +68,7 @@ export default defineConfig(({ mode }) => ({
         manualChunks: {
           'vendor-react': ['react', 'react-dom', 'react-router-dom'],
           'vendor-query': ['@tanstack/react-query'],
-          'vendor-editor': ['@tiptap/react', '@tiptap/starter-kit', '@tiptap/pm', '@tiptap/extension-placeholder'],
+          'vendor-editor': ['@tiptap/react', '@tiptap/starter-kit', '@tiptap/extension-placeholder'],
           'vendor-socket': ['socket.io-client'],
           'vendor-giphy': ['@giphy/js-fetch-api', '@giphy/react-components'],
         },


### PR DESCRIPTION
@tiptap/pm v3.x only exposes subpath exports (e.g. @tiptap/pm/state) and has no root "." entry. Listing it in manualChunks forced Rollup to resolve it as a standalone entry, causing the commonjs-resolver failure. Removing it lets Rollup bundle the subpaths correctly via the packages that import them.