### PR TITLE
fix: resolve mobile room creation z-index and sidebar conflict

### DIFF
--- a/client/src/components/channels/CreateChannelModal.tsx
+++ b/client/src/components/channels/CreateChannelModal.tsx
@@ -55,7 +55,7 @@ export default function CreateChannelModal({ isOpen, onClose, onSuccess }: Creat
     };
 
     return createPortal(
-        <div className="fixed inset-0 z-50 flex items-center justify-center">
+        <div className="fixed inset-0 z-[70] flex items-center justify-center">
             <div
                 className="absolute inset-0 bg-black/60 backdrop-blur-sm"
                 onClick={handleClose}

--- a/client/src/layouts/DashboardLayout.tsx
+++ b/client/src/layouts/DashboardLayout.tsx
@@ -129,7 +129,7 @@ const SidebarContent = ({ onNavigate, isMobile }: SidebarContentProps) => {
         </button>
 
         <div className="pt-4 mt-4 border-t border-white/5">
-          <ChannelListHeader onCreateClick={() => setIsCreateChannelOpen(true)} isMobile={isMobile} />
+          <ChannelListHeader onCreateClick={() => { if (isMobile && onNavigate) onNavigate(); setIsCreateChannelOpen(true); }} isMobile={isMobile} />
           <ChannelList
             isModalOpen={isCreateChannelOpen}
             onModalClose={() => setIsCreateChannelOpen(false)}


### PR DESCRIPTION
- Raise CreateChannelModal z-index to z-[70] so it renders above the mobile sidebar (z-[60])
- Close mobile sidebar before opening the modal to prevent backdrop conflicts