### PR TITLE
feat: landing page redesign

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -4,6 +4,9 @@
 <head>
   <meta charset="UTF-8" />
   <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=Anton&family=Condiment&family=Instrument+Serif&display=swap" rel="stylesheet" />
   <link rel="manifest" href="/site.webmanifest" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
   <title>Silo - Your Batch Space</title>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -12,7 +12,8 @@ import DashboardLayout from '@/layouts/DashboardLayout';
 import InstallPrompt from '@/components/InstallPrompt';
 
 // Lazy-loaded route components — each becomes its own chunk
-const NewLandingPage = lazy(() => import('@/pages/LandingPage'));
+// const NewLandingPage = lazy(() => import('@/pages/LandingPage'));
+const VelorahPage = lazy(() => import('@/pages/VelorahPage'));
 const AboutPage = lazy(() => import('@/pages/AboutPage'));
 const LegalPage = lazy(() => import('@/pages/LegalPage'));
 const LoginForm = lazy(() => import('@/features/auth/LoginForm'));
@@ -68,7 +69,7 @@ const ProtectedRoute = ({ children }: { children: React.ReactNode }) => {
 const router = createBrowserRouter(
   createRoutesFromElements(
     <>
-      <Route path="/welcome" element={<S><NewLandingPage /></S>} />
+      <Route path="/welcome" element={<S><VelorahPage /></S>} />
       <Route path="/about" element={<S><AboutPage /></S>} />
       <Route path="/legal" element={<S><LegalPage /></S>} />
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -255,3 +255,44 @@ a, button, input, textarea, select,
     padding-bottom: env(safe-area-inset-bottom);
   }
 }
+
+/* Velorah — Fade Rise Animations */
+@keyframes fade-rise {
+  from { opacity: 0; transform: translateY(24px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+.animate-fade-rise { animation: fade-rise 0.8s ease-out both; }
+.animate-fade-rise-delay { animation: fade-rise 0.8s ease-out 0.2s both; }
+.animate-fade-rise-delay-2 { animation: fade-rise 0.8s ease-out 0.4s both; }
+
+/* Orbis NFT — Liquid Glass Effect */
+.liquid-glass {
+  background: rgba(255, 255, 255, 0.01);
+  background-blend-mode: luminosity;
+  backdrop-filter: blur(4px);
+  -webkit-backdrop-filter: blur(4px);
+  border: none;
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.1);
+  position: relative;
+  overflow: hidden;
+}
+.liquid-glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.4px;
+  background: linear-gradient(
+    180deg,
+    rgba(255, 255, 255, 0.45) 0%,
+    rgba(255, 255, 255, 0.15) 20%,
+    rgba(255, 255, 255, 0) 40%,
+    rgba(255, 255, 255, 0) 60%,
+    rgba(255, 255, 255, 0.15) 80%,
+    rgba(255, 255, 255, 0.45) 100%
+  );
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+  mask-composite: exclude;
+  pointer-events: none;
+}

--- a/client/src/pages/VelorahPage.tsx
+++ b/client/src/pages/VelorahPage.tsx
@@ -1,0 +1,82 @@
+import { Link } from 'react-router-dom';
+
+const VIDEO_URL =
+  'https://d8j0ntlcm91z4.cloudfront.net/user_38xzZboKViGWJOttwIXH07lWA1P/hf_20260314_131748_f2ca2a28-fed7-44c8-b9a9-bd9acdd5ec31.mp4';
+
+const DISPLAY_FONT = "'Instrument Serif', serif";
+const MUTED = 'hsl(240, 4%, 66%)';
+
+
+export default function VelorahPage() {
+  return (
+    <div className="relative min-h-screen bg-[hsl(201,100%,13%)] text-white overflow-hidden">
+      {/* Video background */}
+      <video
+        src={VIDEO_URL}
+        autoPlay
+        loop
+        muted
+        playsInline
+        className="absolute inset-0 w-full h-full object-cover z-0"
+      />
+
+      {/* Content */}
+      <div className="relative z-10 flex flex-col min-h-screen">
+        {/* Nav */}
+        <nav className="w-full max-w-7xl mx-auto flex flex-row items-center justify-between px-8 py-6">
+          <span className="text-2xl text-white" style={{ fontFamily: "'Press Start 2P', monospace" }}>
+            Silo
+          </span>
+
+          <div className="hidden md:flex items-center gap-8">
+            <a href="#" className="text-sm text-white">Home</a>
+            {[
+              { label: 'About', href: '/about' },
+              { label: 'Legal', href: '/legal' },
+              { label: 'Request Access', href: '/request-access' },
+            ].map(({ label, href }) => (
+              <a
+                key={label}
+                href={href}
+                className="text-sm transition-colors"
+                style={{ color: MUTED }}
+                onMouseEnter={(e) => (e.currentTarget.style.color = 'white')}
+                onMouseLeave={(e) => (e.currentTarget.style.color = MUTED)}
+              >
+                {label}
+              </a>
+            ))}
+          </div>
+
+          <Link to="/request-access" className="liquid-glass rounded-full px-6 py-2.5 text-sm text-white hover:scale-[1.03] transition-transform">
+            Join Silo
+          </Link>
+        </nav>
+
+        {/* Hero */}
+        <section className="flex flex-col items-center justify-center text-center px-6 py-[90px] flex-1">
+          <h1
+            className="text-5xl sm:text-7xl md:text-8xl leading-[0.95] font-normal text-white max-w-7xl animate-fade-rise"
+            style={{ fontFamily: DISPLAY_FONT, letterSpacing: '-2.46px' }}
+          >
+            Where{' '}
+            <em className="not-italic" style={{ color: MUTED }}>students</em>
+            {' '}rise{' '}
+            <em className="not-italic" style={{ color: MUTED }}>beyond the noise.</em>
+          </h1>
+
+          <p
+            className="text-base sm:text-lg max-w-2xl mt-8 leading-relaxed animate-fade-rise-delay"
+            style={{ color: MUTED }}
+          >
+            Built for students who take their work seriously. Notes, discussions, and your batch — all in one focused space. No distractions. Just progress.
+          </p>
+
+          <Link to="/register" className="bg-black/75 backdrop-blur-md border border-white/50 text-white font-semibold rounded-full px-14 py-5 text-base mt-12 hover:bg-black/90 hover:scale-[1.03] transition-all animate-fade-rise-delay-2">
+            Get Started
+          </Link>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/client/tailwind.config.js
+++ b/client/tailwind.config.js
@@ -38,6 +38,8 @@ export default {
           DEFAULT: 'rgb(var(--popover) / <alpha-value>)',
           foreground: 'rgb(var(--popover-foreground) / <alpha-value>)',
         },
+        cream: '#EFF4FF',
+        neon: '#6FFF00',
       },
       borderRadius: {
         lg: 'var(--radius)',
@@ -46,6 +48,8 @@ export default {
       },
       fontFamily: {
         sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+        grotesk: ['Anton', 'sans-serif'],
+        condiment: ['Condiment', 'cursive'],
       },
       boxShadow: {
         'soft': '0 1px 2px 0 rgb(0 0 0 / 0.05)',


### PR DESCRIPTION
## Summary
- New Velorah-style landing page at `/welcome`
- Liquid-glass CSS effect added to global styles
- Anton + Condiment + Instrument Serif fonts loaded
- Tailwind extended with `cream`, `neon` colors and `grotesk`, `condiment` font families
- Old LandingPage commented out, VelorahPage set as default

## Test plan
- [ ] Visit `/welcome` — video background, Silo logo, nav links, hero text, Get Started CTA
- [ ] Get Started → `/register`, Join Silo → `/request-access`