### PR TITLE
feat: dashboard welcome redesign

### DIFF
--- a/client/src/features/academic/DashboardPlaceholder.tsx
+++ b/client/src/features/academic/DashboardPlaceholder.tsx
@@ -1,67 +1,73 @@
 import { Link } from 'react-router-dom';
-import { FileText, HelpCircle, MessageSquare, PenSquare, Send, Trophy, Hash, Zap } from 'lucide-react';
+import { ArrowRight, Trophy } from 'lucide-react';
+
+const DISPLAY_FONT = "'Instrument Serif', serif";
+const MUTED = 'hsl(240, 4%, 66%)';
 
 const quickActions = [
-    { to: '/qna', icon: HelpCircle, label: 'Ask a Question', desc: 'Get help from your batch', color: 'from-blue-500/20 to-blue-600/10', iconColor: 'text-blue-400', border: 'border-blue-500/10 hover:border-blue-500/20' },
-    { to: '/write', icon: PenSquare, label: 'Write Article', desc: 'Share your thoughts', color: 'from-violet-500/20 to-violet-600/10', iconColor: 'text-violet-400', border: 'border-violet-500/10 hover:border-violet-500/20' },
-    { to: '/notes', icon: FileText, label: 'Browse Notes', desc: 'Study materials & resources', color: 'from-emerald-500/20 to-emerald-600/10', iconColor: 'text-emerald-400', border: 'border-emerald-500/10 hover:border-emerald-500/20' },
-    { to: '/chat', icon: MessageSquare, label: 'Batch Chat', desc: 'Chat with your batch', color: 'from-amber-500/20 to-amber-600/10', iconColor: 'text-amber-400', border: 'border-amber-500/10 hover:border-amber-500/20' },
-    { to: '/messages', icon: Send, label: 'Messages', desc: 'Private conversations', color: 'from-cyan-500/20 to-cyan-600/10', iconColor: 'text-cyan-400', border: 'border-cyan-500/10 hover:border-cyan-500/20' },
-    { to: '/channels', icon: Hash, label: 'Channels', desc: 'Join group discussions', color: 'from-pink-500/20 to-pink-600/10', iconColor: 'text-pink-400', border: 'border-pink-500/10 hover:border-pink-500/20' },
+  { to: '/qna', label: 'Ask a Question', desc: 'Get help from your batch' },
+  { to: '/write', label: 'Write Article', desc: 'Share your thoughts' },
+  { to: '/notes', label: 'Browse Notes', desc: 'Study materials & resources' },
+  { to: '/chat', label: 'Batch Chat', desc: 'Chat with your batch' },
+  { to: '/messages', label: 'Messages', desc: 'Private conversations' },
+  { to: '/channels', label: 'Channels', desc: 'Join group discussions' },
 ];
 
-const DashboardPlaceholder = () => {
-    return (
-        <div className="flex flex-col items-center justify-center min-h-[70vh] px-4">
-            {/* Hero section */}
-            <div className="text-center max-w-2xl mb-10 animate-fade-in">
-                <div className="inline-flex items-center gap-2 px-3 py-1.5 rounded-full bg-emerald-500/10 border border-emerald-500/20 mb-6">
-                    <Zap className="w-3.5 h-3.5 text-emerald-400" />
-                    <span className="text-xs font-medium text-emerald-400">Your private campus space</span>
-                </div>
+const DashboardPlaceholder = () => (
+  <div className="flex flex-col items-center justify-center min-h-[70vh] px-4 relative">
+    <div className="absolute top-0 left-1/2 -translate-x-1/2 w-[600px] h-[300px] rounded-full bg-emerald-500/10 blur-[80px] pointer-events-none" />
 
-                <h1 className="text-3xl sm:text-4xl font-bold mb-4">
-                    Welcome to{' '}
-                    <span className="text-gradient-emerald">Silo</span>
-                </h1>
+    {/* Hero */}
+    <div className="text-center max-w-2xl mb-16 animate-fade-rise relative z-10">
+      <h1
+        className="text-5xl sm:text-6xl font-normal leading-[0.95] tracking-[-2px] mb-5 text-white"
+        style={{ fontFamily: DISPLAY_FONT }}
+      >
+        Welcome to{' '}
+        <em className="not-italic text-emerald-400">your space.</em>
+      </h1>
+      <p className="text-sm leading-relaxed max-w-sm mx-auto" style={{ color: MUTED }}>
+        Your batch's private corner — notes, questions, and conversations in one place.
+      </p>
+    </div>
 
-                <p className="text-zinc-400 text-base leading-relaxed max-w-lg mx-auto">
-                    Your batch's private corner of the internet. Ask questions anonymously,
-                    share notes, chat freely, and just be yourself.
-                </p>
-            </div>
+    {/* Pill links */}
+    <div className="flex flex-col w-full max-w-lg animate-fade-rise-delay relative z-10">
+      {quickActions.map((action, index) => (
+        <Link
+          key={action.to}
+          to={action.to}
+          className="group flex items-center justify-between py-4 border-b border-white/8 hover:border-white/20 transition-all duration-200"
+          style={{ animationDelay: `${index * 50}ms` }}
+        >
+          <div className="flex items-center gap-4">
+            <span className="text-xs tabular-nums" style={{ color: MUTED }}>
+              0{index + 1}
+            </span>
+            <span className="text-base font-medium text-white group-hover:text-emerald-400 transition-colors duration-200">
+              {action.label}
+            </span>
+          </div>
+          <ArrowRight
+            className="w-4 h-4 opacity-0 group-hover:opacity-100 -translate-x-2 group-hover:translate-x-0 transition-all duration-200"
+            style={{ color: 'hsl(160, 84%, 39%)' }}
+          />
+        </Link>
+      ))}
+    </div>
 
-            {/* Quick action cards */}
-            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3 w-full max-w-3xl">
-                {quickActions.map((action, index) => (
-                    <Link
-                        key={action.to}
-                        to={action.to}
-                        className={`group relative flex items-start gap-3.5 p-4 rounded-xl bg-gradient-to-br ${action.color} border ${action.border} transition-all duration-300 hover:scale-[1.02] active:scale-[0.98] animate-fade-in`}
-                        style={{ animationDelay: `${index * 60}ms`, opacity: 0, animationFillMode: 'forwards' }}
-                    >
-                        <div className={`flex-shrink-0 w-10 h-10 rounded-xl bg-zinc-900/60 flex items-center justify-center ${action.iconColor} group-hover:scale-110 transition-transform duration-300`}>
-                            <action.icon className="w-5 h-5" />
-                        </div>
-                        <div className="min-w-0">
-                            <h3 className="text-sm font-semibold text-white group-hover:text-white/90">{action.label}</h3>
-                            <p className="text-xs text-zinc-500 mt-0.5">{action.desc}</p>
-                        </div>
-                    </Link>
-                ))}
-            </div>
-
-            {/* Leaderboard teaser */}
-            <Link
-                to="/leaderboard"
-                className="mt-6 flex items-center gap-2 px-4 py-2 rounded-full bg-zinc-900/50 border border-white/5 text-xs text-zinc-400 hover:text-emerald-400 hover:border-emerald-500/20 transition-all duration-300 animate-fade-in"
-                style={{ animationDelay: '400ms', opacity: 0, animationFillMode: 'forwards' }}
-            >
-                <Trophy className="w-3.5 h-3.5" />
-                <span>Check the Leaderboard</span>
-            </Link>
-        </div>
-    );
-};
+    {/* Leaderboard */}
+    <Link
+      to="/leaderboard"
+      className="mt-10 flex items-center gap-2 text-xs transition-colors duration-200 animate-fade-rise-delay-2 relative z-10"
+      style={{ color: MUTED }}
+      onMouseEnter={(e) => (e.currentTarget.style.color = 'white')}
+      onMouseLeave={(e) => (e.currentTarget.style.color = MUTED)}
+    >
+      <Trophy className="w-3.5 h-3.5" />
+      <span>Check the Leaderboard</span>
+    </Link>
+  </div>
+);
 
 export default DashboardPlaceholder;


### PR DESCRIPTION
## Summary
- Instrument Serif heading with emerald accent on dashboard welcome
- Replaced generic cards with editorial numbered pill links
- Ambient emerald glow behind heading
- Arrow slides in on hover, label turns emerald green
- Leaderboard link turns amber on hover

## Test plan
- [ ] `/` (dashboard) — serif heading, numbered list links, hover animations all work
- [ ] Each link navigates to correct route