### PR TITLE
feat: redesign ArticleFeed with editorial overlay cards

### DIFF
--- a/client/src/features/articles/ArticleFeed.tsx
+++ b/client/src/features/articles/ArticleFeed.tsx
@@ -1,13 +1,14 @@
 import { useState, useEffect } from 'react';
 import { Link } from 'react-router-dom';
 import axios from '@/lib/axios';
-import { Clock, CalendarDays, ChevronRight } from 'lucide-react';
+import { Clock } from 'lucide-react';
 import { format } from 'date-fns';
+import { getIdentity } from '@/lib/identity';
 
 interface ArticleData {
     id: string;
     title: string;
-    content: string; // We will extract a snippet from this
+    content: string;
     readTime: number;
     coverImageUrl?: string;
     createdAt: string;
@@ -19,6 +20,11 @@ interface ArticleData {
     };
 }
 
+const stripHtml = (html: string) => {
+    const doc = new DOMParser().parseFromString(html, 'text/html');
+    return doc.body.textContent ?? '';
+};
+
 const ArticleFeed = () => {
     const [articles, setArticles] = useState<ArticleData[]>([]);
     const [isLoading, setIsLoading] = useState(true);
@@ -27,11 +33,12 @@ const ArticleFeed = () => {
     useEffect(() => {
         const fetchArticles = async () => {
             try {
-                const response = await axios.get('/api/articles');
-                setArticles(response.data.articles);
-            } catch (err: any) {
+                const articlesResponse = await axios.get('/api/articles');
+                setArticles(articlesResponse.data.articles);
+            } catch (err: unknown) {
+                const apiError = err as { response?: { data?: { error?: string } } };
                 console.error('Failed to load articles:', err);
-                setError(err.response?.data?.error || 'Failed to load article feed');
+                setError(apiError.response?.data?.error ?? 'Failed to load article feed');
             } finally {
                 setIsLoading(false);
             }
@@ -40,16 +47,10 @@ const ArticleFeed = () => {
         fetchArticles();
     }, []);
 
-    // Utility to strip HTML tags from Tiptap content for the preview snippet
-    const stripHtml = (html: string) => {
-        const doc = new DOMParser().parseFromString(html, 'text/html');
-        return doc.body.textContent || "";
-    };
-
     if (isLoading) {
         return (
             <div className="w-full flex justify-center py-12">
-                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-500"></div>
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-emerald-500" />
             </div>
         );
     }
@@ -64,7 +65,7 @@ const ArticleFeed = () => {
 
     if (articles.length === 0) {
         return (
-            <div className="w-full text-center py-12 px-4 glass-card">
+            <div className="w-full text-center py-12 px-4">
                 <p className="text-zinc-400 mb-4">No articles published in your batch yet.</p>
                 <Link to="/write" className="text-emerald-400 font-medium hover:text-emerald-300 transition-colors">
                     Be the first to write one &rarr;
@@ -74,76 +75,97 @@ const ArticleFeed = () => {
     }
 
     return (
-        <div className="space-y-6 w-full max-w-4xl mx-auto">
-            <div className="flex items-center justify-between mb-8">
-                <h2 className="text-2xl font-bold text-zinc-100 flex items-center gap-2">
-                    <span className="bg-emerald-500 w-2 h-6 rounded-full inline-block"></span>
-                    Latest Articles
-                </h2>
-                {/* Hidden on mobile — use the + FAB button instead */}
-                <Link to="/write" className="hidden md:flex text-sm font-medium text-zinc-300 hover:text-white transition-colors bg-zinc-800 hover:bg-zinc-700 px-4 py-2 rounded-full border border-white/5 shadow-sm">
+        <div className="w-full max-w-4xl mx-auto">
+            <div className="flex items-center justify-end mb-4">
+                <Link
+                    to="/write"
+                    className="hidden md:flex text-sm font-medium text-zinc-300 hover:text-white transition-colors bg-zinc-800 hover:bg-zinc-700 px-4 py-2 rounded-full border border-zinc-700/60"
+                >
                     Write Article
                 </Link>
             </div>
 
-            <div className="grid gap-6">
+            <div className="grid gap-3">
                 {articles.map((article) => {
                     const snippet = stripHtml(article.content).substring(0, 160) + '...';
+                    const authorName = article.author.firstName && article.author.lastName
+                        ? `${article.author.firstName} ${article.author.lastName}`
+                        : article.author.username;
+                    const identity = getIdentity(article.author.id, article.author.username);
 
+                    if (article.coverImageUrl) {
+                        return (
+                            <Link
+                                key={article.id}
+                                to={`/article/${article.id}`}
+                                className="relative block rounded-lg overflow-hidden border border-zinc-800/80 hover:border-zinc-700 group h-52 md:h-64 transition-all duration-150"
+                            >
+                                {/* Cover image */}
+                                <img
+                                    src={article.coverImageUrl}
+                                    alt={article.title}
+                                    className="absolute inset-0 w-full h-full object-cover group-hover:scale-105 transition-transform duration-700 ease-out"
+                                    onError={(e) => { e.currentTarget.style.display = 'none'; }}
+                                />
+
+                                {/* Gradient overlay — top fade for author, bottom fade for title */}
+                                <div className="absolute inset-0 bg-gradient-to-t from-zinc-950 via-zinc-950/60 to-zinc-950/20" />
+
+                                {/* Author row — top */}
+                                <div className="absolute top-0 left-0 right-0 flex items-center gap-2 p-4">
+                                    <img
+                                        src={identity.avatar}
+                                        alt={authorName}
+                                        className="w-5 h-5 rounded-full ring-1 ring-white/20"
+                                    />
+                                    <span className="text-xs font-medium text-white/70">{authorName}</span>
+                                    <span className="text-white/30 text-xs">·</span>
+                                    <span className="text-xs text-white/50">{format(new Date(article.createdAt), 'MMM d')}</span>
+                                </div>
+
+                                {/* Title + meta — bottom */}
+                                <div className="absolute bottom-0 left-0 right-0 p-4">
+                                    <h3 className="text-lg font-semibold text-white leading-snug mb-2 group-hover:text-zinc-100 transition-colors line-clamp-2">
+                                        {article.title}
+                                    </h3>
+                                    <div className="flex items-center gap-1.5 text-xs text-white/40">
+                                        <Clock className="w-3 h-3" />
+                                        <span>{article.readTime} min read</span>
+                                    </div>
+                                </div>
+                            </Link>
+                        );
+                    }
+
+                    // Text-only card (no cover image)
                     return (
                         <Link
                             key={article.id}
                             to={`/article/${article.id}`}
-                            className="block group bg-zinc-900/40 hover:bg-zinc-800/60 border border-white/5 hover:border-white/10 rounded-2xl p-6 md:p-8 transition-all duration-300"
+                            className="block bg-zinc-900 border border-zinc-800/80 hover:border-zinc-700 hover:bg-zinc-800/40 rounded-lg p-4 transition-all duration-150 group"
                         >
-                            <div className="flex flex-col h-full">
-                                <div className="flex items-center gap-3 mb-4">
-                                    <div className="w-8 h-8 rounded-full bg-emerald-500/20 text-emerald-400 flex items-center justify-center font-bold text-sm">
-                                        {article.author.firstName?.[0] || article.author.username?.[0] || '?'}
-                                    </div>
-                                    <div className="text-sm text-zinc-400">
-                                        <span className="font-medium text-zinc-200">
-                                            {article.author.firstName && article.author.lastName
-                                                ? `${article.author.firstName} ${article.author.lastName}`
-                                                : article.author.username}
-                                        </span>
-                                    </div>
-                                    <div className="w-1 h-1 rounded-full bg-zinc-700"></div>
-                                    <div className="text-xs text-zinc-500 flex items-center gap-1.5 hidden sm:flex">
-                                        <CalendarDays className="w-3.5 h-3.5" />
-                                        <span>{format(new Date(article.createdAt), 'MMM d')}</span>
-                                    </div>
-                                </div>
+                            <div className="flex items-center gap-2 text-xs text-zinc-500 mb-2.5">
+                                <img
+                                    src={identity.avatar}
+                                    alt={authorName}
+                                    className="w-5 h-5 rounded-full ring-1 ring-zinc-700/60"
+                                />
+                                <span className="font-medium text-zinc-300">{authorName}</span>
+                                <span className="text-zinc-600">·</span>
+                                <span>{format(new Date(article.createdAt), 'MMM d')}</span>
+                            </div>
 
-                                <h3 className="text-2xl font-bold text-zinc-100 mb-3 group-hover:text-white transition-colors leading-tight">
-                                    {article.title}
-                                </h3>
+                            <h3 className="text-[15px] font-semibold text-zinc-100 leading-snug group-hover:text-white transition-colors mb-1.5 line-clamp-2">
+                                {article.title}
+                            </h3>
 
-                                {article.coverImageUrl && (
-                                    <div className="w-full h-48 md:h-64 rounded-xl overflow-hidden mb-5 border border-white/5 relative z-0">
-                                        <img
-                                            src={article.coverImageUrl}
-                                            alt={article.title}
-                                            className="w-full h-full object-cover select-none group-hover:scale-105 transition-transform duration-700 ease-out"
-                                            onError={(e) => { e.currentTarget.style.display = 'none'; }}
-                                        />
-                                        <div className="absolute inset-0 ring-1 ring-inset ring-black/10 rounded-xl pointer-events-none"></div>
-                                    </div>
-                                )}
+                            <p className="text-sm text-zinc-400 leading-relaxed line-clamp-2 mb-3">
+                                {snippet}
+                            </p>
 
-                                <p className="text-zinc-400 leading-relaxed mb-6 line-clamp-2">
-                                    {snippet}
-                                </p>
-
-                                <div className="mt-auto flex items-center justify-between text-sm text-zinc-500">
-                                    <div className="flex items-center gap-1.5">
-                                        <Clock className="w-4 h-4" />
-                                        <span>{article.readTime} min read</span>
-                                    </div>
-                                    <div className="flex items-center text-zinc-300 font-medium opacity-0 group-hover:opacity-100 transform translate-x-[-10px] group-hover:translate-x-0 transition-all duration-300">
-                                        Read Full Article <ChevronRight className="w-4 h-4 ml-1" />
-                                    </div>
-                                </div>
+                            <div className="flex items-center gap-1.5 text-xs text-zinc-500">
+                                <Clock className="w-3 h-3" />
+                                <span>{article.readTime} min read</span>
                             </div>
                         </Link>
                     );


### PR DESCRIPTION
## Summary
- Articles with cover image render as full-card editorial overlays (Wired/Verge style, not Medium)
- Dual gradient `from-zinc-950 via-zinc-950/60 to-zinc-950/20` — author floats top, title anchors bottom
- Image hover zoom via `group-hover:scale-105 duration-700`
- Articles without cover image use clean text card matching QuestionCard style
- `getIdentity` for consistent robot avatars (replaces inconsistent letter-initial circle)
- Removed redundant "Latest Articles" heading
- `gap-3` spacing consistent with QnA feed

## Test plan
- [ ] Visit `/qna?tab=articles` — image articles show overlay layout
- [ ] Hover article with image — cover scales up
- [ ] Text-only articles render as flat dark cards
- [ ] Author avatars use robot icons (not letter circles)
- [ ] Write Article button visible desktop, hidden mobile
- [ ] Empty state shows with link to `/write`